### PR TITLE
Fix time parting variable

### DIFF
--- a/tf/binding_custom_code.js
+++ b/tf/binding_custom_code.js
@@ -14,7 +14,7 @@ function s_doPlugins(s) {
   s.eVar1 = _satellite.getVar("content: page name");
   s.eVar34 = s.getTimeParting('d', '-5');
   s.eVar35 = s.getTimeParting('h', '-5');
-  s.eVar37 = s.getTimeParting('w', '-5');
+  s.eVar32 = s.getTimeParting('w', '-5');
   s.prop36 = "D=v34";
   s.prop37 = "D=v35";
   s.prop38 = "D=v32";


### PR DESCRIPTION
## Summary
- correct weekday time parting variable

## Testing
- `node -e "var fs=require('fs'); try { new Function(fs.readFileSync('tf/binding_custom_code.js', 'utf8')); console.log('ok'); } catch(e) { console.error(e); }"`

------
https://chatgpt.com/codex/tasks/task_e_688d041f79f08323b286aadb54819ae3